### PR TITLE
Refactor plugin

### DIFF
--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -57,8 +57,7 @@ class QuarantinePlugin(object):
 
         try:
             with open(self.quarantine) as f:
-                for nodeid in f:
-                    self.nodeids.add(nodeid.strip())
+                self.nodeids = {nodeid.strip() for nodeid in f}
         except IOError:
             # TODO: Would it be better to warn or abort?
             pass

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -11,7 +11,7 @@ DEFAULT_QUARANTINE = "quarantine.txt"
 
 
 class SaveQuarantinePlugin(object):
-    """Save a list of failing tests to be marked as xfail on future test runs."""
+    """Save the list of failing tests to a quarantine file."""
 
     def __init__(self, config):
         self.save_quarantine = config.getoption("save_quarantine")
@@ -38,7 +38,7 @@ class SaveQuarantinePlugin(object):
 
 
 class QuarantinePlugin(object):
-    """Mark a list of tests in a file as xfail."""
+    """Mark each test listed in a quarantine file as xfail."""
 
     def __init__(self, config):
         self.quarantine = config.getoption("quarantine")
@@ -51,7 +51,7 @@ class QuarantinePlugin(object):
         return "{}: {}".format("quarantine", self.quarantine)
 
     def pytest_runtestloop(self, session):
-        """Read the ID's of quarantined tests from a file."""
+        """Read test ID's from a file into the quarantine."""
         if not self.quarantine:
             return
 
@@ -63,7 +63,7 @@ class QuarantinePlugin(object):
             pass
 
     def pytest_runtest_setup(self, item):
-        """Mark a test as `xfail` if its ID is in the quarantine."""
+        """Mark a test as xfail if its ID is in the quarantine."""
         if self.quarantine and item.nodeid in self.nodeids:
             item.add_marker(pytest.mark.xfail(reason="Quarantined"))
 

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -13,15 +13,13 @@ DEFAULT_QUARANTINE = "quarantine.txt"
 class SaveQuarantinePlugin(object):
     """Save the list of failing tests to a quarantine file."""
 
-    def __init__(self, config):
-        self.save_quarantine = config.getoption("save_quarantine")
+    def __init__(self, quarantine_path):
+        self.quarantine_path = quarantine_path
         self.nodeids = set()
 
     def pytest_report_header(self, config):
         """Display configuration at runtime."""
-        if not self.save_quarantine:
-            return None
-        return "{}: {}".format("save_quarantine", self.save_quarantine)
+        return "{}: {}".format("save_quarantine", self.quarantine_path)
 
     def pytest_runtest_logreport(self, report):
         """Save the ID of a failed test to the quarantine."""
@@ -30,33 +28,28 @@ class SaveQuarantinePlugin(object):
 
     def pytest_sessionfinish(self, session):
         """Write the ID's of quarantined tests to a file."""
-        if not (self.save_quarantine and self.nodeids):
+        if not self.nodeids:
             return
 
-        with open(self.save_quarantine, "w") as f:
+        with open(self.quarantine_path, "w") as f:
             f.writelines(nodeid + "\n" for nodeid in sorted(self.nodeids))
 
 
 class QuarantinePlugin(object):
     """Mark each test listed in a quarantine file as xfail."""
 
-    def __init__(self, config):
-        self.quarantine = config.getoption("quarantine")
+    def __init__(self, quarantine_path):
+        self.quarantine_path = quarantine_path
         self.nodeids = set()
 
     def pytest_report_header(self, config):
         """Display configuration at runtime."""
-        if not self.quarantine:
-            return None
-        return "{}: {}".format("quarantine", self.quarantine)
+        return "{}: {}".format("quarantine", self.quarantine_path)
 
     def pytest_runtestloop(self, session):
         """Read test ID's from a file into the quarantine."""
-        if not self.quarantine:
-            return
-
         try:
-            with open(self.quarantine) as f:
+            with open(self.quarantine_path) as f:
                 self.nodeids = {nodeid.strip() for nodeid in f}
         except IOError:
             # TODO: Would it be better to warn or abort?
@@ -64,18 +57,23 @@ class QuarantinePlugin(object):
 
     def pytest_runtest_setup(self, item):
         """Mark a test as xfail if its ID is in the quarantine."""
-        if self.quarantine and item.nodeid in self.nodeids:
+        if item.nodeid in self.nodeids:
             item.add_marker(pytest.mark.xfail(reason="Quarantined"))
 
 
 def pytest_configure(config):
     """Register the plugin functionality."""
-    # TODO: Only register when the options are present?
-    # It could remove the guard conditionals in the classes.
-    config.pluginmanager.register(
-        SaveQuarantinePlugin(config), "save_quarantine_plugin"
-    )
-    config.pluginmanager.register(QuarantinePlugin(config), "quarantine_plugin")
+    save_quarantine_path = config.getoption("save_quarantine")
+    if save_quarantine_path:
+        config.pluginmanager.register(
+            SaveQuarantinePlugin(save_quarantine_path), "save_quarantine_plugin"
+        )
+
+    quarantine_path = config.getoption("quarantine")
+    if quarantine_path:
+        config.pluginmanager.register(
+            QuarantinePlugin(quarantine_path), "quarantine_plugin"
+        )
 
 
 def pytest_addoption(parser):

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -42,6 +42,11 @@ def failing_tests(testdir):
     )
 
 
+def test_no_report_header_without_options(testdir):
+    result = testdir.runpytest()
+    assert "quarantine: " not in result.stdout.str()
+
+
 @pytest.mark.parametrize("quarantine_path", [None, ".quarantine"])
 def test_save_failing_tests(quarantine_path, testdir, failing_tests):
     args = ["--save-quarantine"]

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -115,6 +115,21 @@ def test_partial_quarantine(testdir, failing_tests):
     result.assert_outcomes(passed=1, error=1, xfailed=1)
 
 
+def test_passing_quarantine(testdir, failing_tests):
+    quarantine = textwrap.dedent(
+        """\
+        test_failing_tests.py::test_pass
+        test_failing_tests.py::test_error
+        test_failing_tests.py::test_failure
+        """
+    )
+    testdir.tmpdir.join(DEFAULT_QUARANTINE).write(quarantine)
+
+    result = testdir.runpytest("--quarantine")
+
+    result.assert_outcomes(xfailed=2, xpassed=1)
+
+
 def test_missing_quarantine(testdir, failing_tests):
     result = testdir.runpytest("--quarantine")
 


### PR DESCRIPTION
Split plugin class into two: one for each option, registered only when command line options are present.