### PR TITLE
Report size of quarantine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ target/
 
 # pyenv
 .python-version
+
+# pytest-quarantine development
+quarantine.txt
+.quarantine

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ With this plugin, you can save all of existing failures to a file (the quarantin
 
 ## Installation
 
-Via [pip](https://pypi.org/project/pip/) from [PyPI](https://pypi.org/project/pytest-quarantine):
+Via [pip](https://pypi.org/project/pip/) from [PyPI](https://pypi.org/project/pytest-quarantine) in an active [virtual environment](https://docs.python.org/3/tutorial/venv.html):
 
 ```
 $ pip install pytest-quarantine
@@ -37,8 +37,14 @@ Run your test suite and save the failing tests to `quarantine.txt`:
 
 ```
 $ pytest --save-quarantine
+============================= test session starts ==============================
+...
+collected 1380 items
 
-= 629 failed, 719 passed, 32 error in 312.56 seconds =
+...
+
+---------------------- 661 items saved to quarantine.txt -----------------------
+============== 629 failed, 719 passed, 32 error in 312.56 seconds ==============
 ```
 
 Add `quarantine.txt` to your version control system.
@@ -47,8 +53,14 @@ Run your test suite with the quarantined tests marked as expected failures:
 
 ```
 $ pytest --quarantine
+============================= test session starts ==============================
+...
+collected 1380 items
+added mark.xfail to 661 of 661 items from quarantine.txt
 
-= 719 passed, 661 xfailed in 300.51 seconds =
+...
+
+================== 719 passed, 661 xfailed in 300.51 seconds ===================
 ```
 
 When the expected failures eventually pass (i.e., they get counted as `xpassed`), they can be removed manually from `quarantine.txt`, or automatically using `--save-quarantine`. Note that the latter will overwrite the contents of the quarantine, so it's best to only use it when running the entire test suite.

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -12,7 +12,7 @@ DEFAULT_QUARANTINE = "quarantine.txt"
 
 def _quarantine_size(nodeids):
     num_tests = len(nodeids)
-    return "{} test{}".format(num_tests, "" if num_tests == 1 else "s")
+    return "{} item{}".format(num_tests, "" if num_tests == 1 else "s")
 
 
 class SaveQuarantinePlugin(object):

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -50,9 +50,12 @@ class QuarantinePlugin(object):
         except IOError as exc:
             raise pytest.UsageError("Could not load quarantine: " + str(exc))
 
-    def pytest_report_header(self, config):
+    def pytest_report_collectionfinish(self):
         """Display configuration at runtime."""
-        return "{}: {}".format("quarantine", self.quarantine_path)
+        num_tests = len(self.nodeids)
+        return "quarantine: {} test{} in {}".format(
+            num_tests, "" if num_tests == 1 else "s", self.quarantine_path
+        )
 
     def pytest_runtest_setup(self, item):
         """Mark a test as xfail if its ID is in the quarantine."""

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -10,9 +10,9 @@ import pytest
 DEFAULT_QUARANTINE = "quarantine.txt"
 
 
-def _quarantine_size(nodeids):
-    num_tests = len(nodeids)
-    return "{} item{}".format(num_tests, "" if num_tests == 1 else "s")
+def _item_count(nodeids):
+    count = len(nodeids)
+    return "{} item{}".format(count, "" if count == 1 else "s")
 
 
 class SaveQuarantinePlugin(object):
@@ -35,7 +35,7 @@ class SaveQuarantinePlugin(object):
         terminalreporter.write_sep(
             "-",
             "{} saved to {}".format(
-                _quarantine_size(self.quarantine_ids), self.quarantine_path
+                _item_count(self.quarantine_ids), self.quarantine_path
             ),
         )
 
@@ -72,14 +72,9 @@ class QuarantinePlugin(object):
 
     def pytest_report_collectionfinish(self):
         """Display number of quarantined items before running tests."""
-        report_status = "quarantine: {} from {}".format(
-            _quarantine_size(self.marked_ids), self.quarantine_path
+        return "added mark.xfail to {} of {} from {}".format(
+            len(self.marked_ids), _item_count(self.quarantine_ids), self.quarantine_path
         )
-
-        if len(self.marked_ids) != len(self.quarantine_ids):
-            report_status += " ({} total)".format(len(self.quarantine_ids))
-
-        return report_status
 
 
 def pytest_configure(config):

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -63,7 +63,7 @@ class QuarantinePlugin(object):
         except IOError as exc:
             raise pytest.UsageError("Could not load quarantine: " + str(exc))
 
-    def pytest_report_collectionfinish(self):
+    def pytest_report_header(self):
         """Display size of quarantine before running tests."""
         return "quarantine: {} in {}".format(
             _quarantine_size(self.nodeids), self.quarantine_path

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -64,12 +64,6 @@ class QuarantinePlugin(object):
         except IOError as exc:
             raise pytest.UsageError("Could not load quarantine: " + str(exc))
 
-    def pytest_report_header(self):
-        """Display size of quarantine before running tests."""
-        return "quarantine: {} in {}".format(
-            _quarantine_size(self.nodeids), self.quarantine_path
-        )
-
     def pytest_itemcollected(self, item):
         """Mark a test as xfail if its ID is in the quarantine."""
         if item.nodeid in self.nodeids:
@@ -78,9 +72,14 @@ class QuarantinePlugin(object):
 
     def pytest_report_collectionfinish(self):
         """Display number of quarantined items before running tests."""
-        return "quarantined {}".format(
+        report_status = "quarantine: {} from {}".format(
             _quarantine_size(self.marked_ids), self.quarantine_path
         )
+
+        if len(self.marked_ids) != len(self.nodeids):
+            report_status += " ({} total)".format(len(self.nodeids))
+
+        return report_status
 
 
 def pytest_configure(config):

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -29,6 +29,9 @@ class SaveQuarantinePlugin(object):
 
     def pytest_terminal_summary(self, terminalreporter):
         """Display size of quarantine after running tests."""
+        if not self.nodeids:
+            return
+
         terminalreporter.write_sep(
             "-",
             "{} saved to {}".format(

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -134,27 +134,34 @@ def test_full_quarantine(quarantine_path, testdir, failing_tests):
     result = testdir.runpytest(*args)
 
     result.stdout.fnmatch_lines(
-        ["quarantine: {}".format(quarantine_path), "collected*"]
+        ["collected*", "quarantine: 2 tests in {}".format(quarantine_path)]
     )
     result.assert_outcomes(passed=1, xfailed=2)
     assert result.ret == EXIT_OK
 
 
 def test_partial_quarantine(testdir, failing_tests):
+    quarantine_path = DEFAULT_QUARANTINE
+
     quarantine = textwrap.dedent(
         """\
         test_failing_tests.py::test_failure
         """
     )
-    testdir.tmpdir.join(DEFAULT_QUARANTINE).write(quarantine)
+    testdir.tmpdir.join(quarantine_path).write(quarantine)
 
     result = testdir.runpytest("--quarantine")
 
+    result.stdout.fnmatch_lines(
+        ["collected*", "quarantine: 1 test in {}".format(quarantine_path)]
+    )
     result.assert_outcomes(passed=1, error=1, xfailed=1)
     assert result.ret == EXIT_TESTSFAILED
 
 
 def test_passing_quarantine(testdir, failing_tests):
+    quarantine_path = DEFAULT_QUARANTINE
+
     quarantine = textwrap.dedent(
         """\
         test_failing_tests.py::test_pass
@@ -162,7 +169,7 @@ def test_passing_quarantine(testdir, failing_tests):
         test_failing_tests.py::test_failure
         """
     )
-    testdir.tmpdir.join(DEFAULT_QUARANTINE).write(quarantine)
+    testdir.tmpdir.join(quarantine_path).write(quarantine)
 
     result = testdir.runpytest("--quarantine")
 

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -67,7 +67,9 @@ def test_save_failing_tests(quarantine_path, testdir, failing_tests):
 
     result = testdir.runpytest(*args)
 
-    result.stdout.fnmatch_lines(["save_quarantine: {}".format(quarantine_path)])
+    result.stdout.fnmatch_lines(
+        ["save_quarantine: {}".format(quarantine_path), "collected*"]
+    )
     result.assert_outcomes(passed=1, failed=1, error=1)
     assert result.ret == EXIT_TESTSFAILED
 
@@ -131,7 +133,9 @@ def test_full_quarantine(quarantine_path, testdir, failing_tests):
 
     result = testdir.runpytest(*args)
 
-    result.stdout.fnmatch_lines(["quarantine: {}".format(quarantine_path)])
+    result.stdout.fnmatch_lines(
+        ["quarantine: {}".format(quarantine_path), "collected*"]
+    )
     result.assert_outcomes(passed=1, xfailed=2)
     assert result.ret == EXIT_OK
 

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -137,7 +137,7 @@ def test_full_quarantine(quarantine_path, testdir, two_failing_tests):
     result = testdir.runpytest(*args)
 
     result.stdout.fnmatch_lines(
-        ["collected*", "quarantine: 2 tests in {}".format(quarantine_path)]
+        ["quarantine: 2 tests in {}".format(quarantine_path), "collected*"]
     )
     result.assert_outcomes(passed=1, xfailed=2)
     assert result.ret == EXIT_OK
@@ -156,7 +156,7 @@ def test_partial_quarantine(testdir, two_failing_tests):
     result = testdir.runpytest("--quarantine")
 
     result.stdout.fnmatch_lines(
-        ["collected*", "quarantine: 1 test in {}".format(quarantine_path)]
+        ["quarantine: 1 test in {}".format(quarantine_path), "collected*"]
     )
     result.assert_outcomes(passed=1, error=1, xfailed=1)
     assert result.ret == EXIT_TESTSFAILED

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -52,9 +52,9 @@ def two_failing_tests(testdir):
     )
 
 
-def test_no_report_header_without_options(testdir):
+def test_no_output_without_options(testdir):
     result = testdir.runpytest()
-    assert "quarantine: " not in result.outlines
+    assert DEFAULT_QUARANTINE not in result.stdout.str()
 
 
 @pytest.mark.parametrize("quarantine_path", [None, ".quarantine"])
@@ -83,6 +83,8 @@ def test_save_failing_tests(quarantine_path, testdir, two_failing_tests):
 
 
 def test_no_save_with_passing_tests(testdir):
+    quarantine_path = DEFAULT_QUARANTINE
+
     testdir.makepyfile(
         """\
         import pytest
@@ -96,7 +98,8 @@ def test_no_save_with_passing_tests(testdir):
 
     result.assert_outcomes(passed=1)
     assert result.ret == EXIT_OK
-    assert testdir.tmpdir.join(DEFAULT_QUARANTINE).check(exists=False)
+    assert quarantine_path not in result.stdout.str()
+    assert testdir.tmpdir.join(quarantine_path).check(exists=False)
 
 
 @pytest.mark.parametrize("quarantine_path", [None, ".quarantine"])

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -31,7 +31,7 @@ def test_options(testdir):
 
 
 @pytest.fixture
-def failing_tests(testdir):
+def two_failing_tests(testdir):
     return testdir.makepyfile(
         test_failing_tests="""\
         import pytest
@@ -58,7 +58,7 @@ def test_no_report_header_without_options(testdir):
 
 
 @pytest.mark.parametrize("quarantine_path", [None, ".quarantine"])
-def test_save_failing_tests(quarantine_path, testdir, failing_tests):
+def test_save_failing_tests(quarantine_path, testdir, two_failing_tests):
     args = ["--save-quarantine"]
     if quarantine_path:
         args.append(quarantine_path)
@@ -68,7 +68,7 @@ def test_save_failing_tests(quarantine_path, testdir, failing_tests):
     result = testdir.runpytest(*args)
 
     result.stdout.fnmatch_lines(
-        ["save_quarantine: {}".format(quarantine_path), "collected*"]
+        ["*- 2 tests saved to {} -*".format(quarantine_path), "=*failed*"]
     )
     result.assert_outcomes(passed=1, failed=1, error=1)
     assert result.ret == EXIT_TESTSFAILED
@@ -116,7 +116,7 @@ def test_missing_quarantine(quarantine_path, testdir):
 
 
 @pytest.mark.parametrize("quarantine_path", [None, ".quarantine"])
-def test_full_quarantine(quarantine_path, testdir, failing_tests):
+def test_full_quarantine(quarantine_path, testdir, two_failing_tests):
     args = ["--quarantine"]
     if quarantine_path:
         args.append(quarantine_path)
@@ -140,7 +140,7 @@ def test_full_quarantine(quarantine_path, testdir, failing_tests):
     assert result.ret == EXIT_OK
 
 
-def test_partial_quarantine(testdir, failing_tests):
+def test_partial_quarantine(testdir, two_failing_tests):
     quarantine_path = DEFAULT_QUARANTINE
 
     quarantine = textwrap.dedent(
@@ -159,7 +159,7 @@ def test_partial_quarantine(testdir, failing_tests):
     assert result.ret == EXIT_TESTSFAILED
 
 
-def test_passing_quarantine(testdir, failing_tests):
+def test_passing_quarantine(testdir, two_failing_tests):
     quarantine_path = DEFAULT_QUARANTINE
 
     quarantine = textwrap.dedent(

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -68,7 +68,7 @@ def test_save_failing_tests(quarantine_path, testdir, error_and_failure):
     result = testdir.runpytest(*args)
 
     result.stdout.fnmatch_lines(
-        ["*- 2 tests saved to {} -*".format(quarantine_path), "=*failed*"]
+        ["*- 2 items saved to {} -*".format(quarantine_path), "=*failed*"]
     )
     result.assert_outcomes(passed=1, failed=1, error=1)
     assert result.ret == EXIT_TESTSFAILED
@@ -137,7 +137,7 @@ def test_full_quarantine(quarantine_path, testdir, error_and_failure):
     result = testdir.runpytest(*args)
 
     result.stdout.fnmatch_lines(
-        ["collected*", "quarantine: 2 tests from {}".format(quarantine_path)]
+        ["collected*", "quarantine: 2 items from {}".format(quarantine_path)]
     )
     result.assert_outcomes(passed=1, xfailed=2)
     assert result.ret == EXIT_OK
@@ -157,7 +157,7 @@ def test_partial_quarantine(testdir, error_and_failure):
     result = testdir.runpytest("--quarantine")
 
     result.stdout.fnmatch_lines(
-        ["collected*", "quarantine: 1 test from {} (2 total)".format(quarantine_path)]
+        ["collected*", "quarantine: 1 item from {} (2 total)".format(quarantine_path)]
     )
     result.assert_outcomes(passed=1, error=1, xfailed=1)
     assert result.ret == EXIT_TESTSFAILED
@@ -176,7 +176,7 @@ def test_only_extra_quarantine(testdir, error_and_failure):
     result = testdir.runpytest("--quarantine")
 
     result.stdout.fnmatch_lines(
-        ["collected*", "quarantine: 0 tests from {} (1 total)".format(quarantine_path)]
+        ["collected*", "quarantine: 0 items from {} (1 total)".format(quarantine_path)]
     )
     result.assert_outcomes(passed=1, failed=1, error=1)
     assert result.ret == EXIT_TESTSFAILED
@@ -197,7 +197,7 @@ def test_passing_quarantine(testdir, error_and_failure):
     result = testdir.runpytest("--quarantine")
 
     result.stdout.fnmatch_lines(
-        ["collected*", "quarantine: 3 tests from {}".format(quarantine_path)]
+        ["collected*", "quarantine: 3 items from {}".format(quarantine_path)]
     )
     result.assert_outcomes(xfailed=2, xpassed=1)
     assert result.ret == EXIT_OK

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -137,11 +137,7 @@ def test_full_quarantine(quarantine_path, testdir, error_and_failure):
     result = testdir.runpytest(*args)
 
     result.stdout.fnmatch_lines(
-        [
-            "quarantine: 2 tests in {}".format(quarantine_path),
-            "collected*",
-            "quarantined 2 tests",
-        ]
+        ["collected*", "quarantine: 2 tests from {}".format(quarantine_path)]
     )
     result.assert_outcomes(passed=1, xfailed=2)
     assert result.ret == EXIT_OK
@@ -153,6 +149,7 @@ def test_partial_quarantine(testdir, error_and_failure):
     quarantine = textwrap.dedent(
         """\
         test_failing_tests.py::test_failure
+        test_failing_tests.py::test_extra
         """
     )
     testdir.tmpdir.join(quarantine_path).write(quarantine)
@@ -160,17 +157,13 @@ def test_partial_quarantine(testdir, error_and_failure):
     result = testdir.runpytest("--quarantine")
 
     result.stdout.fnmatch_lines(
-        [
-            "quarantine: 1 test in {}".format(quarantine_path),
-            "collected*",
-            "quarantined 1 test",
-        ]
+        ["collected*", "quarantine: 1 test from {} (2 total)".format(quarantine_path)]
     )
     result.assert_outcomes(passed=1, error=1, xfailed=1)
     assert result.ret == EXIT_TESTSFAILED
 
 
-def test_extra_quarantine(testdir, error_and_failure):
+def test_only_extra_quarantine(testdir, error_and_failure):
     quarantine_path = DEFAULT_QUARANTINE
 
     quarantine = textwrap.dedent(
@@ -183,11 +176,7 @@ def test_extra_quarantine(testdir, error_and_failure):
     result = testdir.runpytest("--quarantine")
 
     result.stdout.fnmatch_lines(
-        [
-            "quarantine: 1 test in {}".format(quarantine_path),
-            "collected*",
-            "quarantined 0 tests",
-        ]
+        ["collected*", "quarantine: 0 tests from {} (1 total)".format(quarantine_path)]
     )
     result.assert_outcomes(passed=1, failed=1, error=1)
     assert result.ret == EXIT_TESTSFAILED
@@ -208,11 +197,7 @@ def test_passing_quarantine(testdir, error_and_failure):
     result = testdir.runpytest("--quarantine")
 
     result.stdout.fnmatch_lines(
-        [
-            "quarantine: 3 tests in {}".format(quarantine_path),
-            "collected*",
-            "quarantined 3 tests",
-        ]
+        ["collected*", "quarantine: 3 tests from {}".format(quarantine_path)]
     )
     result.assert_outcomes(xfailed=2, xpassed=1)
     assert result.ret == EXIT_OK

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -137,7 +137,10 @@ def test_full_quarantine(quarantine_path, testdir, error_and_failure):
     result = testdir.runpytest(*args)
 
     result.stdout.fnmatch_lines(
-        ["collected*", "quarantine: 2 items from {}".format(quarantine_path)]
+        [
+            "collected*",
+            "added mark.xfail to 2 of 2 items from {}".format(quarantine_path),
+        ]
     )
     result.assert_outcomes(passed=1, xfailed=2)
     assert result.ret == EXIT_OK
@@ -157,7 +160,10 @@ def test_partial_quarantine(testdir, error_and_failure):
     result = testdir.runpytest("--quarantine")
 
     result.stdout.fnmatch_lines(
-        ["collected*", "quarantine: 1 item from {} (2 total)".format(quarantine_path)]
+        [
+            "collected*",
+            "added mark.xfail to 1 of 2 items from {}".format(quarantine_path),
+        ]
     )
     result.assert_outcomes(passed=1, error=1, xfailed=1)
     assert result.ret == EXIT_TESTSFAILED
@@ -176,7 +182,10 @@ def test_only_extra_quarantine(testdir, error_and_failure):
     result = testdir.runpytest("--quarantine")
 
     result.stdout.fnmatch_lines(
-        ["collected*", "quarantine: 0 items from {} (1 total)".format(quarantine_path)]
+        [
+            "collected*",
+            "added mark.xfail to 0 of 1 item from {}".format(quarantine_path),
+        ]
     )
     result.assert_outcomes(passed=1, failed=1, error=1)
     assert result.ret == EXIT_TESTSFAILED
@@ -197,7 +206,10 @@ def test_passing_quarantine(testdir, error_and_failure):
     result = testdir.runpytest("--quarantine")
 
     result.stdout.fnmatch_lines(
-        ["collected*", "quarantine: 3 items from {}".format(quarantine_path)]
+        [
+            "collected*",
+            "added mark.xfail to 3 of 3 items from {}".format(quarantine_path),
+        ]
     )
     result.assert_outcomes(xfailed=2, xpassed=1)
     assert result.ret == EXIT_OK


### PR DESCRIPTION
Instead of just showing the quarantine file at the beginning of the session.

- Show the number of tests read from the quarantine when using the `--quarantine` option
- Show the number of tests saved to the quarantine when using the `--save-quarantine` option
- Add tests and tweak existing ones