### PR TITLE
Use attrs for readability

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ maintainer_email = brian@bhrutledge.com
 [options]
 py_modules = pytest_quarantine
 install_requires =
+    attrs
     pytest>=4.6
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 package_dir = =src

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
+import attr
 import pytest
 
 
@@ -15,12 +16,12 @@ def _item_count(nodeids):
     return "{} item{}".format(count, "" if count == 1 else "s")
 
 
+@attr.s(cmp=False)
 class SaveQuarantinePlugin(object):
     """Save the list of failing tests to a quarantine file."""
 
-    def __init__(self, quarantine_path):
-        self.quarantine_path = quarantine_path
-        self.quarantine_ids = set()
+    quarantine_path = attr.ib()
+    quarantine_ids = attr.ib(init=False, factory=set)
 
     def pytest_runtest_logreport(self, report):
         """Save the ID of a failed test to the quarantine."""
@@ -48,14 +49,14 @@ class SaveQuarantinePlugin(object):
             f.writelines(nodeid + "\n" for nodeid in sorted(self.quarantine_ids))
 
 
+@attr.s(cmp=False)
 class QuarantinePlugin(object):
     """Mark each test listed in a quarantine file as xfail."""
 
-    def __init__(self, quarantine_path, verbose):
-        self.quarantine_path = quarantine_path
-        self.verbose = verbose
-        self.quarantine_ids = set()
-        self.marked_ids = set()
+    quarantine_path = attr.ib()
+    verbose = attr.ib()
+    quarantine_ids = attr.ib(init=False, factory=set)
+    marked_ids = attr.ib(init=False, factory=set)
 
     def pytest_sessionstart(self, session):
         """Read test ID's from a file into the quarantine."""


### PR DESCRIPTION
Using `attr.s(cmp=False)` to use Python's default hashing by `id()` to avoid `TypeError: unhashable type` from pytest.

`cmp` is deprecated in 19.2.0 (replaced by `eq`), but opting to maintain backwards compatibility for now.

See:
https://www.attrs.org/en/18.2.0/hashing.html
http://www.attrs.org/en/19.2.0/changelog.html#deprecations

<!--
Thanks for helping to improve this project! To help ensure that your contribution is aligned with the goals of this project, please include a reference to an open issue that’s been discussed (unless it's a small/quick fix), followed by a description of your changes, and how you tested them.

Checks for consistent style, coding errors, and test coverage will run automatically. In general, only pull requests with passing tests and checks will be merged..
-->
