### PR TITLE
Require quarantine path on command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- --save-quarantine can overwrite test files ([#29](https://github.com/EnergySage/pytest-quarantine/issues/29))
+
 ## [1.2.0] - 2019-11-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ pip install pytest-quarantine
 Run your test suite and save the failing tests to `quarantine.txt`:
 
 ```
-$ pytest --save-quarantine
+$ pytest --save-quarantine=quarantine.txt
 ============================= test session starts ==============================
 ...
 collected 1380 items
@@ -52,7 +52,7 @@ Add `quarantine.txt` to your version control system.
 Run your test suite with the quarantined tests marked as expected failures:
 
 ```
-$ pytest --quarantine
+$ pytest --quarantine=quarantine.txt
 ============================= test session starts ==============================
 ...
 collected 1380 items
@@ -64,14 +64,6 @@ added mark.xfail to 661 of 661 items from quarantine.txt
 ```
 
 When the expected failures eventually pass (i.e., they get counted as `xpassed`), they can be removed manually from `quarantine.txt`, or automatically using `--save-quarantine`. Note that the latter will overwrite the contents of the quarantine, so it's best to only use it when running the entire test suite.
-
-The default `quarantine.txt` can be changed by an optional argument (for example, if test failures differ between environments, or for multiple test suites):
-
-```
-$ pytest --save-quarantine=quarantine-py3.txt
-
-$ pytest --quarantine=quarantine-py3.txt
-```
 
 ## Getting help
 

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -15,11 +15,6 @@ import attr
 import pytest
 
 
-# TODO: Guarantee this is opened from pytest's root dir
-# (to allow running pytest in a subdirectory)
-DEFAULT_QUARANTINE = "quarantine.txt"
-
-
 def _item_count(nodeids):
     count = len(nodeids)
     return "{} item{}".format(count, "" if count == 1 else "s")

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -124,16 +124,12 @@ def pytest_addoption(parser):
 
     group.addoption(
         "--save-quarantine",
-        nargs="?",
-        const=DEFAULT_QUARANTINE,
         metavar="PATH",
-        help="Write failing tests to %(metavar)s (default: %(const)s)",
+        help="Write failing test ID's to %(metavar)s",
     )
 
     group.addoption(
         "--quarantine",
-        nargs="?",
-        const=DEFAULT_QUARANTINE,
         metavar="PATH",
-        help="Mark tests listed in %(metavar)s with `xfail` (default: %(const)s)",
+        help="Mark test ID's listed in %(metavar)s with `xfail`",
     )

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -15,18 +15,14 @@ except AttributeError:
     # Python 2), use the private constants for readability.
     from _pytest.main import EXIT_OK, EXIT_TESTSFAILED, EXIT_USAGEERROR  # noqa: F401
 
-from pytest_quarantine import DEFAULT_QUARANTINE
-
-
-def test_default_file():
-    assert DEFAULT_QUARANTINE == "quarantine.txt"
+QUARANTINE_PATH = "quarantine.txt"
 
 
 def test_options_in_help(testdir):
     result = testdir.runpytest("--help")
 
     result.stdout.fnmatch_lines(
-        ["quarantine:", "*--save-quarantine=PATH", "*--quarantine=PATH*"]
+        ["quarantine:", "*--save-quarantine=PATH*", "*--quarantine=PATH*"]
     )
 
 
@@ -61,9 +57,11 @@ def error_failed_passed(testdir):
     )
 
 
-def test_no_output_without_options(testdir):
+def test_no_output_without_options(testdir, error_failed_passed):
     result = testdir.runpytest()
-    assert DEFAULT_QUARANTINE not in result.stdout.str()
+
+    assert result.ret == EXIT_TESTSFAILED
+    assert QUARANTINE_PATH not in result.stdout.str()
 
 
 @pytest.fixture
@@ -83,19 +81,17 @@ def testdir(testdir):
     return testdir
 
 
-@pytest.mark.parametrize("quarantine_path", [DEFAULT_QUARANTINE, ".quarantine"])
-def test_save_failing_tests(quarantine_path, testdir, error_failed_passed):
-    args = ["--save-quarantine", quarantine_path]
-    result = testdir.runpytest(*args)
+def test_save_failing_tests(testdir, error_failed_passed):
+    result = testdir.runpytest("--save-quarantine", QUARANTINE_PATH)
 
     assert result.ret == EXIT_TESTSFAILED
     result.assert_outcomes(passed=1, failed=1, error=1)
     result.stdout.fnmatch_lines(
-        ["*- 2 items saved to {} -*".format(quarantine_path), "=*failed*"]
+        ["*- 2 items saved to {} -*".format(QUARANTINE_PATH), "=*failed*"]
     )
 
     assert testdir.path_has_content(
-        quarantine_path,
+        QUARANTINE_PATH,
         """\
         test_error_failed_passed.py::test_error
         test_error_failed_passed.py::test_failed
@@ -104,9 +100,6 @@ def test_save_failing_tests(quarantine_path, testdir, error_failed_passed):
 
 
 def test_dont_save_other_outcomes(testdir):
-    quarantine_path = DEFAULT_QUARANTINE
-    args = ["--save-quarantine", quarantine_path]
-
     testdir.makepyfile(
         """\
         import pytest
@@ -128,21 +121,18 @@ def test_dont_save_other_outcomes(testdir):
         """
     )
 
-    result = testdir.runpytest(*args)
+    result = testdir.runpytest("--save-quarantine", QUARANTINE_PATH)
 
     assert result.ret == EXIT_OK
     result.assert_outcomes(passed=1, skipped=1, xpassed=1, xfailed=1)
     result.stdout.fnmatch_lines(
-        ["*- 0 items saved to {} -*".format(quarantine_path), "=*skipped*"]
+        ["*- 0 items saved to {} -*".format(QUARANTINE_PATH), "=*skipped*"]
     )
 
-    assert testdir.path_has_content(quarantine_path, "")
+    assert testdir.path_has_content(QUARANTINE_PATH, "")
 
 
 def test_save_empty_quarantine(testdir):
-    quarantine_path = DEFAULT_QUARANTINE
-    args = ["--save-quarantine", quarantine_path]
-
     testdir.makepyfile(
         test_xpassed="""\
         def test_passed():
@@ -151,112 +141,97 @@ def test_save_empty_quarantine(testdir):
     )
 
     testdir.write_path(
-        quarantine_path,
+        QUARANTINE_PATH,
         """\
         test_xpassed.py::test_passed
         """,
     )
 
-    result = testdir.runpytest(*args)
+    result = testdir.runpytest("--save-quarantine", QUARANTINE_PATH)
 
     assert result.ret == EXIT_OK
     result.assert_outcomes(passed=1)
     result.stdout.fnmatch_lines(
-        ["*- 0 items saved to {} -*".format(quarantine_path), "=*passed*"]
+        ["*- 0 items saved to {} -*".format(QUARANTINE_PATH), "=*passed*"]
     )
 
-    assert testdir.path_has_content(quarantine_path, "")
+    assert testdir.path_has_content(QUARANTINE_PATH, "")
 
 
-@pytest.mark.parametrize("quarantine_path", [DEFAULT_QUARANTINE, ".quarantine"])
-def test_missing_quarantine(quarantine_path, testdir):
-    args = ["--quarantine", quarantine_path]
-
-    result = testdir.runpytest(*args)
+def test_missing_quarantine(testdir):
+    result = testdir.runpytest("--quarantine", QUARANTINE_PATH)
 
     assert result.ret == EXIT_USAGEERROR
     result.stderr.fnmatch_lines(
-        ["ERROR: Could not load quarantine:*'{}'".format(quarantine_path)]
+        ["ERROR: Could not load quarantine:*'{}'".format(QUARANTINE_PATH)]
     )
 
 
-@pytest.mark.parametrize("quarantine_path", [DEFAULT_QUARANTINE, ".quarantine"])
-def test_full_quarantine(quarantine_path, testdir, error_failed_passed):
-    args = ["--quarantine", quarantine_path]
-
+def test_full_quarantine(testdir, error_failed_passed):
     testdir.write_path(
-        quarantine_path,
+        QUARANTINE_PATH,
         """\
         test_error_failed_passed.py::test_error
         test_error_failed_passed.py::test_failed
         """,
     )
 
-    result = testdir.runpytest(*args)
+    result = testdir.runpytest("--quarantine", QUARANTINE_PATH)
 
     assert result.ret == EXIT_OK
     result.assert_outcomes(passed=1, xfailed=2)
     result.stdout.fnmatch_lines(
         [
             "collected*",
-            "added mark.xfail to 2 of 2 items from {}".format(quarantine_path),
+            "added mark.xfail to 2 of 2 items from {}".format(QUARANTINE_PATH),
         ]
     )
 
 
 def test_partial_quarantine(testdir, error_failed_passed):
-    quarantine_path = DEFAULT_QUARANTINE
-    args = ["--quarantine", quarantine_path]
-
     testdir.write_path(
-        quarantine_path,
+        QUARANTINE_PATH,
         """\
         test_error_failed_passed.py::test_failed
         test_error_failed_passed.py::test_extra
         """,
     )
 
-    result = testdir.runpytest(*args)
+    result = testdir.runpytest("--quarantine", QUARANTINE_PATH)
 
     assert result.ret == EXIT_TESTSFAILED
     result.assert_outcomes(passed=1, error=1, xfailed=1)
     result.stdout.fnmatch_lines(
         [
             "collected*",
-            "added mark.xfail to 1 of 2 items from {}".format(quarantine_path),
+            "added mark.xfail to 1 of 2 items from {}".format(QUARANTINE_PATH),
         ]
     )
 
 
 def test_only_extra_quarantine(testdir, error_failed_passed):
-    quarantine_path = DEFAULT_QUARANTINE
-    args = ["--quarantine", quarantine_path]
-
     testdir.write_path(
-        quarantine_path,
+        QUARANTINE_PATH,
         """\
         test_error_failed_passed.py::test_extra
         """,
     )
 
-    result = testdir.runpytest(*args)
+    result = testdir.runpytest("--quarantine", QUARANTINE_PATH)
 
     assert result.ret == EXIT_TESTSFAILED
     result.assert_outcomes(passed=1, failed=1, error=1)
     result.stdout.fnmatch_lines(
         [
             "collected*",
-            "added mark.xfail to 0 of 1 item from {}".format(quarantine_path),
+            "added mark.xfail to 0 of 1 item from {}".format(QUARANTINE_PATH),
         ]
     )
 
 
 def test_passing_quarantine(testdir, error_failed_passed):
-    quarantine_path = DEFAULT_QUARANTINE
-    args = ["--quarantine", quarantine_path]
-
     testdir.write_path(
-        quarantine_path,
+        QUARANTINE_PATH,
         """\
         test_error_failed_passed.py::test_error
         test_error_failed_passed.py::test_failed
@@ -264,29 +239,26 @@ def test_passing_quarantine(testdir, error_failed_passed):
         """,
     )
 
-    result = testdir.runpytest(*args)
+    result = testdir.runpytest("--quarantine", QUARANTINE_PATH)
 
     assert result.ret == EXIT_OK
     result.assert_outcomes(xfailed=2, xpassed=1)
     result.stdout.fnmatch_lines(
         [
             "collected*",
-            "added mark.xfail to 3 of 3 items from {}".format(quarantine_path),
+            "added mark.xfail to 3 of 3 items from {}".format(QUARANTINE_PATH),
         ]
     )
 
 
 def test_no_report_with_quiet_option(testdir, error_failed_passed):
-    quarantine_path = DEFAULT_QUARANTINE
-    args = ["-q", "--quarantine", quarantine_path]
-
     testdir.write_path(
-        quarantine_path,
+        QUARANTINE_PATH,
         """\
         test_error_failed_passed.py::test_error
         """,
     )
 
-    result = testdir.runpytest(*args)
+    result = testdir.runpytest("-q", "--quarantine", QUARANTINE_PATH)
 
-    assert quarantine_path not in result.stdout.str()
+    assert QUARANTINE_PATH not in result.stdout.str()


### PR DESCRIPTION
Fixes #29. As discussed in that issue, this makes the plugin's code, tests, and documentation simpler by removing conditional clauses.

I'm thinking this probably warrants a 2.0 release, since it breaks the existing command line behavior.

<!--
Thanks for helping to improve this project! To help ensure that your contribution is aligned with the goals of this project, please include a reference to an open issue that’s been discussed (unless it's a small/quick fix), followed by a description of your changes, and how you tested them.

Checks for consistent style, coding errors, and test coverage will run automatically. In general, only pull requests with passing tests and checks will be merged..
-->