### PR TITLE
Write quarantine during test run

### DIFF
--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -47,7 +47,12 @@ class SaveQuarantinePlugin(object):
         Results in an empty file if all tests are passing, to remove previously failed
         tests from the quarantine.
         """
-        self.quarantine = open(self.quarantine_path, "w", buffering=1, encoding="utf-8")
+        try:
+            self.quarantine = open(
+                self.quarantine_path, "w", buffering=1, encoding="utf-8"
+            )
+        except IOError as exc:
+            raise pytest.UsageError("Could not open quarantine: " + str(exc))
 
     def pytest_runtest_logreport(self, report):
         """Save the ID of a failed test to the quarantine."""
@@ -93,7 +98,7 @@ class QuarantinePlugin(object):
             with open(self.quarantine_path, encoding="utf-8") as f:
                 self.quarantine_ids = {nodeid.strip() for nodeid in f}
         except IOError as exc:
-            raise pytest.UsageError("Could not load quarantine: " + str(exc))
+            raise pytest.UsageError("Could not open quarantine: " + str(exc))
 
     def pytest_itemcollected(self, item):
         """Mark a test as xfail if its ID is in the quarantine."""

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -11,6 +11,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
+import argparse
+import os
+
 import attr
 import pytest
 
@@ -120,6 +123,7 @@ def pytest_addoption(parser):
     group.addoption(
         "--save-quarantine",
         metavar="PATH",
+        type=_filename,
         help="Write failing test ID's to %(metavar)s",
     )
 
@@ -128,3 +132,11 @@ def pytest_addoption(parser):
         metavar="PATH",
         help="Mark test ID's listed in %(metavar)s with `xfail`",
     )
+
+
+def _filename(value):
+    if os.path.isdir(value):
+        raise argparse.ArgumentTypeError(
+            "'{}' is a directory; must be a file path".format(value)
+        )
+    return value

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -5,8 +5,9 @@ failures on future test runs.
 
 Inspired by:
     - https://github.com/pytest-dev/pytest/blob/master/src/_pytest/cacheprovider.py
+    - https://github.com/pytest-dev/pytest-reportlog/blob/master/src/pytest_reportlog/plugin.py
     - https://github.com/hackebrot/pytest-md/blob/master/src/pytest_md/plugin.py
-"""
+"""  # noqa: E501
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
@@ -26,8 +27,7 @@ def _file_path(value):
     return value
 
 
-def _item_count(nodeids):
-    count = len(nodeids)
+def _item_count(count):
     return "{} item{}".format(count, "" if count == 1 else "s")
 
 
@@ -71,35 +71,42 @@ class SaveQuarantinePlugin(object):
 
     Attributes:
         quarantine_path (str): The path to the quarantine file
-        quarantine_ids (Set[int]):
-            The ID's of failed tests to write to ``quarantine_path``
+        quarantine (IO[str]): The opened quarantine file
+        quarantine_count (int]):
+            The number of failed tests written to ``quarantine_path``
     """
 
     quarantine_path = attr.ib()
-    quarantine_ids = attr.ib(init=False, factory=set)
+    quarantine = attr.ib(init=False, default=None)
+    quarantine_count = attr.ib(init=False, default=0)
+
+    def pytest_sessionstart(self):
+        """Open the quarantine for writing.
+
+        Results in an empty file if all tests are passing, to remove previously failed
+        tests from the quarantine.
+        """
+        self.quarantine = open(self.quarantine_path, "w")
 
     def pytest_runtest_logreport(self, report):
         """Save the ID of a failed test to the quarantine."""
         if report.failed:
-            self.quarantine_ids.add(report.nodeid)
+            self.quarantine.write(report.nodeid + "\n")
+            self.quarantine_count += 1
 
     def pytest_terminal_summary(self, terminalreporter):
         """Display size of quarantine after running tests."""
         terminalreporter.write_sep(
             "-",
             "{} saved to {}".format(
-                _item_count(self.quarantine_ids), self.quarantine_path
+                _item_count(self.quarantine_count), self.quarantine_path
             ),
         )
 
     def pytest_sessionfinish(self, session):
-        """Write the ID's of quarantined tests to a file.
-
-        Writes an empty file if all tests are passing, to remove previously failed tests
-        from the quarantine.
-        """
-        with open(self.quarantine_path, "w") as f:
-            f.writelines(nodeid + "\n" for nodeid in sorted(self.quarantine_ids))
+        """Close the quarantine."""
+        if self.quarantine:
+            self.quarantine.close()
 
 
 @attr.s(cmp=False)
@@ -137,6 +144,6 @@ class QuarantinePlugin(object):
         if self.verbose >= 0:
             return "added mark.xfail to {} of {} from {}".format(
                 len(self.marked_ids),
-                _item_count(self.quarantine_ids),
+                _item_count(len(self.quarantine_ids)),
                 self.quarantine_path,
             )

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -12,9 +12,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
-import argparse
 import logging
-import os
 from io import open
 
 import attr
@@ -22,14 +20,6 @@ import pytest
 
 
 logger = logging.getLogger(__name__)
-
-
-def _file_path(value):
-    if os.path.isdir(value):
-        raise argparse.ArgumentTypeError(
-            "'{}' is a directory; must be a file path".format(value)
-        )
-    return value
 
 
 def _item_count(count):
@@ -43,7 +33,6 @@ def pytest_addoption(parser):
     group.addoption(
         "--save-quarantine",
         metavar="PATH",
-        type=_file_path,
         help="Write failing test ID's to %(metavar)s",
     )
 

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -13,10 +13,14 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import argparse
+import logging
 import os
 
 import attr
 import pytest
+
+
+logger = logging.getLogger(__name__)
 
 
 def _file_path(value):
@@ -107,6 +111,7 @@ class SaveQuarantinePlugin(object):
         """Close the quarantine."""
         if self.quarantine:
             self.quarantine.close()
+            logger.debug("Closed " + self.quarantine_path)
 
 
 @attr.s(cmp=False)

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -26,39 +26,6 @@ def _item_count(count):
     return "{} item{}".format(count, "" if count == 1 else "s")
 
 
-def pytest_addoption(parser):
-    """Add command line options to the 'quarantine' group."""
-    group = parser.getgroup("quarantine")
-
-    group.addoption(
-        "--save-quarantine",
-        metavar="PATH",
-        help="Write failing test ID's to %(metavar)s",
-    )
-
-    group.addoption(
-        "--quarantine",
-        metavar="PATH",
-        help="Mark test ID's listed in %(metavar)s with `xfail`",
-    )
-
-
-def pytest_configure(config):
-    """Register the plugin functionality."""
-    save_quarantine_path = config.getoption("save_quarantine")
-    if save_quarantine_path:
-        config.pluginmanager.register(
-            SaveQuarantinePlugin(save_quarantine_path), "save_quarantine_plugin"
-        )
-
-    quarantine_path = config.getoption("quarantine")
-    if quarantine_path:
-        config.pluginmanager.register(
-            QuarantinePlugin(quarantine_path, config.getoption("verbose")),
-            "quarantine_plugin",
-        )
-
-
 @attr.s(cmp=False)
 class SaveQuarantinePlugin(object):
     """Save the list of failing tests to a quarantine file.
@@ -142,3 +109,36 @@ class QuarantinePlugin(object):
                 _item_count(len(self.quarantine_ids)),
                 self.quarantine_path,
             )
+
+
+def pytest_configure(config):
+    """Register the plugin functionality."""
+    save_quarantine_path = config.getoption("save_quarantine")
+    if save_quarantine_path:
+        config.pluginmanager.register(
+            SaveQuarantinePlugin(save_quarantine_path), "save_quarantine_plugin"
+        )
+
+    quarantine_path = config.getoption("quarantine")
+    if quarantine_path:
+        config.pluginmanager.register(
+            QuarantinePlugin(quarantine_path, config.getoption("verbose")),
+            "quarantine_plugin",
+        )
+
+
+def pytest_addoption(parser):
+    """Add command line options to the 'quarantine' group."""
+    group = parser.getgroup("quarantine")
+
+    group.addoption(
+        "--save-quarantine",
+        metavar="PATH",
+        help="Write failing test ID's to %(metavar)s",
+    )
+
+    group.addoption(
+        "--quarantine",
+        metavar="PATH",
+        help="Mark test ID's listed in %(metavar)s with `xfail`",
+    )

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -107,7 +107,7 @@ class SaveQuarantinePlugin(object):
             ),
         )
 
-    def pytest_sessionfinish(self, session):
+    def pytest_unconfigure(self):
         """Close the quarantine."""
         if self.quarantine:
             self.quarantine.close()

--- a/src/pytest_quarantine.py
+++ b/src/pytest_quarantine.py
@@ -15,6 +15,7 @@ from __future__ import unicode_literals
 import argparse
 import logging
 import os
+from io import open
 
 import attr
 import pytest
@@ -90,7 +91,7 @@ class SaveQuarantinePlugin(object):
         Results in an empty file if all tests are passing, to remove previously failed
         tests from the quarantine.
         """
-        self.quarantine = open(self.quarantine_path, "w")
+        self.quarantine = open(self.quarantine_path, "w", buffering=1, encoding="utf-8")
 
     def pytest_runtest_logreport(self, report):
         """Save the ID of a failed test to the quarantine."""
@@ -133,7 +134,7 @@ class QuarantinePlugin(object):
     def pytest_sessionstart(self, session):
         """Read test ID's from a file into the quarantine."""
         try:
-            with open(self.quarantine_path) as f:
+            with open(self.quarantine_path, encoding="utf-8") as f:
                 self.quarantine_ids = {nodeid.strip() for nodeid in f}
         except IOError as exc:
             raise pytest.UsageError("Could not load quarantine: " + str(exc))

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -10,11 +10,17 @@ import pytest
 try:
     EXIT_OK = pytest.ExitCode.OK
     EXIT_TESTSFAILED = pytest.ExitCode.TESTS_FAILED
+    EXIT_INTERNALERROR = pytest.ExitCode.INTERNAL_ERROR
     EXIT_USAGEERROR = pytest.ExitCode.USAGE_ERROR
 except AttributeError:
     # ExitCode was introduced in pytest 5.0.0. As long as we support pytest 4.6 (for
     # Python 2), use the private constants for readability.
-    from _pytest.main import EXIT_OK, EXIT_TESTSFAILED, EXIT_USAGEERROR  # noqa: F401
+    from _pytest.main import (
+        EXIT_OK,
+        EXIT_TESTSFAILED,
+        EXIT_INTERNALERROR,
+        EXIT_USAGEERROR,
+    )
 
 QUARANTINE_PATH = "quarantine.txt"
 
@@ -159,12 +165,19 @@ def test_save_empty_quarantine(testdir):
     assert testdir.path_has_content(QUARANTINE_PATH, "")
 
 
-def test_save_closes_quarantine(caplog, testdir):
+def test_save_always_closes_quarantine(caplog, testdir):
     caplog.set_level(logging.DEBUG)
+
+    testdir.makeconftest(
+        """\
+        def pytest_runtestloop():
+            raise Exception()
+        """
+    )
 
     result = testdir.runpytest("--save-quarantine", QUARANTINE_PATH)
 
-    result.stdout.fnmatch_lines(["*- 0 items saved to {} -*".format(QUARANTINE_PATH)])
+    assert result.ret == EXIT_INTERNALERROR
     assert "Closed " + QUARANTINE_PATH in caplog.text
 
 

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -158,6 +158,15 @@ def test_save_empty_quarantine(testdir):
     assert testdir.path_has_content(QUARANTINE_PATH, "")
 
 
+def test_save_dir_error(testdir, error_failed_passed):
+    testdir.mkdir("quarantine")
+
+    result = testdir.runpytest("--save-quarantine", "quarantine")
+
+    assert result.ret == EXIT_USAGEERROR
+    result.stderr.fnmatch_lines(["*error:*file path*"])
+
+
 def test_missing_quarantine(testdir):
     result = testdir.runpytest("--quarantine", QUARANTINE_PATH)
 

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -182,12 +182,14 @@ def test_save_always_closes_quarantine(caplog, testdir):
 
 
 def test_save_dir_error(testdir, error_failed_passed):
-    testdir.mkdir("quarantine")
+    quarantine_path = "quarantine"
 
-    result = testdir.runpytest("--save-quarantine", "quarantine")
+    testdir.mkdir(quarantine_path)
 
-    assert result.ret == EXIT_USAGEERROR
-    result.stderr.fnmatch_lines(["*error:*file path*"])
+    result = testdir.runpytest("--save-quarantine", quarantine_path)
+
+    assert result.ret == EXIT_INTERNALERROR
+    result.stdout.fnmatch_lines(["INTERNALERROR>*'{}'*".format(quarantine_path)])
 
 
 def test_missing_quarantine(testdir):

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
+import logging
 import textwrap
 
 import pytest
@@ -156,6 +157,15 @@ def test_save_empty_quarantine(testdir):
     )
 
     assert testdir.path_has_content(QUARANTINE_PATH, "")
+
+
+def test_save_closes_quarantine(caplog, testdir):
+    caplog.set_level(logging.DEBUG)
+
+    result = testdir.runpytest("--save-quarantine", QUARANTINE_PATH)
+
+    result.stdout.fnmatch_lines(["*- 0 items saved to {} -*".format(QUARANTINE_PATH)])
+    assert "Closed " + QUARANTINE_PATH in caplog.text
 
 
 def test_save_dir_error(testdir, error_failed_passed):

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -183,13 +183,14 @@ def test_save_always_closes_quarantine(caplog, testdir):
 
 def test_save_dir_error(testdir, error_failed_passed):
     quarantine_path = "quarantine"
-
     testdir.mkdir(quarantine_path)
 
     result = testdir.runpytest("--save-quarantine", quarantine_path)
 
-    assert result.ret == EXIT_INTERNALERROR
-    result.stdout.fnmatch_lines(["INTERNALERROR>*'{}'*".format(quarantine_path)])
+    assert result.ret == EXIT_USAGEERROR
+    result.stderr.fnmatch_lines(
+        ["ERROR: Could not open quarantine:*'{}'".format(quarantine_path)]
+    )
 
 
 def test_missing_quarantine(testdir):
@@ -197,7 +198,7 @@ def test_missing_quarantine(testdir):
 
     assert result.ret == EXIT_USAGEERROR
     result.stderr.fnmatch_lines(
-        ["ERROR: Could not load quarantine:*'{}'".format(QUARANTINE_PATH)]
+        ["ERROR: Could not open quarantine:*'{}'".format(QUARANTINE_PATH)]
     )
 
 


### PR DESCRIPTION
Fixes #31 by opening the quarantine file at the beginning of the test run, which results in a usage error if the path is a directory, doesn't have permissions, etc.

This means that if the test run is interrupted, the quarantine file will be changed (and incomplete), but since it should be in version control, that seems like an acceptable trade-off.

Added tests for using a directory as the path, to ensure that the file is closed.
<!--
Thanks for helping to improve this project! To help ensure that your contribution is aligned with the goals of this project, please include a reference to an open issue that’s been discussed (unless it's a small/quick fix), followed by a description of your changes, and how you tested them.

Checks for consistent style, coding errors, and test coverage will run automatically. In general, only pull requests with passing tests and checks will be merged..
-->
